### PR TITLE
Fix several issues related to processing of malformed ELF files

### DIFF
--- a/src/abstract_segments.cpp
+++ b/src/abstract_segments.cpp
@@ -97,7 +97,7 @@ void AbstractSegments::createDynamic()
             m_offset = program.getPhysOffset();
             m_size = program.getSize();
 
-            if (m_offset <= m_sizeFile && m_size <= m_sizeFile )
+            if (m_offset + m_size <= m_sizeFile)
             {
                 m_dynamic.createDynamic(m_data, m_offset,
                                         m_size, m_baseAddress,

--- a/src/dynamicsection.cpp
+++ b/src/dynamicsection.cpp
@@ -84,10 +84,6 @@ void DynamicSection::createDynamic(const char *p_start, boost::uint32_t p_offset
     {
         uint64_t value = entry.getValue();
 
-        if(value > m_fileSize) {
-            throw std::runtime_error("Unexpected dynamic entry value.");
-        }
-
         switch (entry.getTag())
         {
         case elf::dynamic::k_symtab:
@@ -103,7 +99,11 @@ void DynamicSection::createDynamic(const char *p_start, boost::uint32_t p_offset
         case elf::dynamic::k_gnuhash:
             if (m_symbolTableSize == 0 && value <= m_fileSize)
             {
-                const boost::uint32_t *hashStart = reinterpret_cast<const boost::uint32_t *>(p_start + (entry.getValue() - p_baseAddress));
+                if (value - p_baseAddress > m_fileSize) {
+                    throw std::runtime_error("Unexpected dynamic entry value.");
+                }
+
+                const boost::uint32_t *hashStart = reinterpret_cast<const boost::uint32_t *>(p_start + (value - p_baseAddress));
                 ++hashStart;
                 m_symbolTableSize = *hashStart;
                 if (!p_isLE)

--- a/src/dynamicsection.cpp
+++ b/src/dynamicsection.cpp
@@ -74,11 +74,7 @@ void DynamicSection::createDynamic(const char *p_start, boost::uint32_t p_offset
         {
             BOOST_FOREACH (AbstractDynamicEntry &entry, m_entries)
             {
-                if (offset <= m_fileSize) {
-                    entry.createString(p_start + offset);
-                } else {
-                    throw std::runtime_error("Unexpected dynamic section offset.");
-                }
+                entry.createString(p_start + offset);
             }
         }
     }

--- a/src/dynamicsection.cpp
+++ b/src/dynamicsection.cpp
@@ -74,7 +74,11 @@ void DynamicSection::createDynamic(const char *p_start, boost::uint32_t p_offset
         {
             BOOST_FOREACH (AbstractDynamicEntry &entry, m_entries)
             {
-                entry.createString(p_start + offset);
+                if (offset <= m_fileSize) {
+                    entry.createString(p_start + offset);
+                } else {
+                    throw std::runtime_error("Unexpected dynamic section offset.");
+                }
             }
         }
     }

--- a/src/dynamicsection.cpp
+++ b/src/dynamicsection.cpp
@@ -87,6 +87,11 @@ void DynamicSection::createDynamic(const char *p_start, boost::uint32_t p_offset
     BOOST_FOREACH (const AbstractDynamicEntry &entry, m_entries)
     {
         uint64_t value = entry.getValue();
+
+        if(value > m_fileSize) {
+            throw std::runtime_error("Unexpected dynamic entry value.");
+        }
+
         switch (entry.getTag())
         {
         case elf::dynamic::k_symtab:

--- a/src/elfparser.cpp
+++ b/src/elfparser.cpp
@@ -148,7 +148,7 @@ void ELFParser::parse(const std::string &p_file)
     m_size =  m_elfHeader.getProgramSize();
     m_pc =  m_elfHeader.getProgramCount();
 
-    if(m_offset * m_size * m_pc <= m_fileSize)
+    if(m_offset + (m_size * m_pc) <= m_fileSize)
     {
         m_programHeader.setHeaders(ptrDataMem + m_offset,
                                m_pc,
@@ -161,7 +161,7 @@ void ELFParser::parse(const std::string &p_file)
     m_size = m_elfHeader.getSectionSize();
     m_pc =  m_elfHeader.getSectionCount();
 
-    if(m_offset * m_size * m_pc <= m_fileSize)
+    if(m_offset + (m_size * m_pc) <= m_fileSize)
     {
 
         m_sectionHeader.setHeaders(ptrDataMem, m_offset,

--- a/src/elfparser.cpp
+++ b/src/elfparser.cpp
@@ -148,7 +148,7 @@ void ELFParser::parse(const std::string &p_file)
     m_size =  m_elfHeader.getProgramSize();
     m_pc =  m_elfHeader.getProgramCount();
 
-    if( m_offset <= m_fileSize && m_size <= m_fileSize )
+    if(m_offset * m_size * m_pc <= m_fileSize)
     {
         m_programHeader.setHeaders(ptrDataMem + m_offset,
                                m_pc,
@@ -161,7 +161,7 @@ void ELFParser::parse(const std::string &p_file)
     m_size = m_elfHeader.getSectionSize();
     m_pc =  m_elfHeader.getSectionCount();
 
-    if(m_offset <= m_fileSize && m_size <= m_fileSize)
+    if(m_offset * m_size * m_pc <= m_fileSize)
     {
 
         m_sectionHeader.setHeaders(ptrDataMem, m_offset,

--- a/src/sectionheaders.cpp
+++ b/src/sectionheaders.cpp
@@ -55,10 +55,14 @@ void SectionHeaders::setHeaders(const char *p_data, uint32_t p_offset, const cha
                                           p_stringIndex, m_sectionHeaders,
                                           p_is64, p_isLE);
             if (m_sectionHeaders.back().getType() != elf::k_nobits &&
-                (m_sectionHeaders.back().getPhysOffset() + m_sectionHeaders.back().getSize()) > m_totalSize)
+                (
+                    (m_sectionHeaders.back().getPhysOffset() + m_sectionHeaders.back().getSize()) > m_totalSize ||
+                    (m_sectionHeaders.back().getPhysOffset() > UINT64_MAX - m_sectionHeaders.back().getSize()) // Overflow check
+                )
+            )
             {
                 m_sectionHeaders.pop_back();
-                p_capabilities[elf::k_antidebug].insert("Invalid sections entries in section table , check offsets, possible malformed elf ");
+                p_capabilities[elf::k_antidebug].insert("Invalid sections entries in section table, check offsets, possible malformed elf ");
             }
         }
     }

--- a/src/sectionheaders.hpp
+++ b/src/sectionheaders.hpp
@@ -5,6 +5,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <boost/cstdint.hpp>
 
 #include "structures/capabilities.hpp"

--- a/src/segment_types/note_segment.cpp
+++ b/src/segment_types/note_segment.cpp
@@ -48,6 +48,11 @@ NoteSegment::NoteSegment(const char *p_start, boost::uint32_t p_offset, boost::u
     m_description()
 {
     m_note = reinterpret_cast<const elf::note *>(p_start + p_offset);
+
+    if (m_note->m_nameSize + m_note->m_descSize + sizeof(elf::note) > p_size) {
+        throw std::runtime_error("Unexpected Note segment size.");
+    }
+
     if (m_note->m_nameSize > 1 && m_note->m_nameSize < p_size)
     {
         m_name.assign(p_start + p_offset + sizeof(elf::note),


### PR DESCRIPTION
Hello! I've been doing some fuzzing recently, and found several issues related to processing malformed ELF files. Those are pretty much all out-of-bound reads, which mostly lead to crashes.

I've written several fixes for these. Where possible, I improve existing bounds checks, so "slightly" broken ELFs still can be loaded. In other places, I throw std::runtime_error() to avoid segfault.

I also added some missing includes, so the app compiles with more modern compilers.

I've also noticed that tests (elfparser-cli-ng_test) are broken. They are already broken on current master branch, so it's not caused by me changes. I'm not sure how to best fix those, so I just left them as-is.